### PR TITLE
fix for msvc 19

### DIFF
--- a/MiniLua/MiniLua.cpp
+++ b/MiniLua/MiniLua.cpp
@@ -96,7 +96,7 @@ bool MiniLua::Get(const char *name, float &result) {
   double temp {};
   if (this->Get(name, temp) == false)
     return false;
-  result = (float){(float)temp};
+  result = {(float)temp};
   return true;
 }
 

--- a/MiniLua/MiniLua.cpp
+++ b/MiniLua/MiniLua.cpp
@@ -96,7 +96,7 @@ bool MiniLua::Get(const char *name, float &result) {
   double temp {};
   if (this->Get(name, temp) == false)
     return false;
-  result = {(float)temp};
+  result = float(temp);
   return true;
 }
 


### PR DESCRIPTION
error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax
this error is shown upon compiling the file with msvc 19 and c++17. using what I provide might work as a temporary fix until a better fix has been thought off.